### PR TITLE
Fix CI by switching to windows-2019

### DIFF
--- a/.github/workflows/build-conda-packages.yml
+++ b/.github/workflows/build-conda-packages.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ['x64']
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-2019, ubuntu-latest, macos-latest]
         python: ['3.6', '3.7', '3.8', '3.9']
         exclude:
           - arch: x86


### PR DESCRIPTION
github updated the windows CI version, so we switch to back to windows-2019 (from windows-latest).