### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/build-conda-packages.yml
+++ b/.github/workflows/build-conda-packages.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         arch: ['x64']
         os: [windows-2019, ubuntu-latest, macos-latest]
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11']
         exclude:
           - arch: x86
             os: macos-latest


### PR DESCRIPTION
fixes #33. No rebuilds are required. Next packages will just not be built for Python 3.7 anymore.