### PR TITLE
use ubuntu 20.04 in CI

### DIFF
--- a/.github/workflows/build-conda-packages.yml
+++ b/.github/workflows/build-conda-packages.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ['x64']
-        os: [windows-2019, ubuntu-latest, macos-latest]
+        os: [windows-2019, ubuntu-20.04, macos-latest]
         python: ['3.7', '3.8', '3.9', '3.10', '3.11']
         exclude:
           - arch: x86

--- a/opencascade/meta.yaml
+++ b/opencascade/meta.yaml
@@ -16,7 +16,7 @@ source:
     - dlr-feature-coons_c2.patch
 
 build:
-  number: 8
+  number: 9
   detect_binary_files_with_prefix: True
 
 requirements:

--- a/python-occ-7x/meta.yaml
+++ b/python-occ-7x/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-DLR-patch-to-support-c2-continous-coons-patches.patch
 
 build:
-  number: 7
+  number: 8
   binary_relocation: false [osx]
 
 requirements:

--- a/tigl3/meta.yaml
+++ b/tigl3/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_tag: v{{ version }}
 
 build:
-  number: 2
+  number: 3
 
 
 requirements:

--- a/tixi3/meta.yaml
+++ b/tixi3/meta.yaml
@@ -12,7 +12,7 @@ source:
     - disabled-fortran-example.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
After #29 was merged, Ubuntu 20.04 CI started failing at https://github.com/dlr-sc/tigl due to a glibc conflict. Ubuntu 22.04 builds seem to be uneffected. This PR is a desperate attempt to see if building the packages on Ubuntu 20.04 resolves this issue.