### PR TITLE
cpacscreator: introduce qt with version range as run requirement

### DIFF
--- a/cpacscreator/meta.yaml
+++ b/cpacscreator/meta.yaml
@@ -43,6 +43,7 @@ requirements:
 
   run:
     - tixi3 ==3.3.0
+    - qt >=5.15.7,<6.0.0
     - pyqt >=5.15.7,<6.0.0
     - opencascade ==7.4.0
     - pythonocc-core ==7.4.1

--- a/cpacscreator/meta.yaml
+++ b/cpacscreator/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_tag: cpacscreator-v{{ version }}
 
 build:
-  number: 1
+  number: 2
 
 
 requirements:
@@ -39,12 +39,12 @@ requirements:
     - tbb-devel ==2019.5
     - python {{ python }}
     - libglu                            # [linux]
-    - qt >=5.15.7,<6.0.0
+    - qt >=5.9.7,<6.0.0
 
   run:
     - tixi3 ==3.3.0
-    - qt >=5.15.7,<6.0.0
-    - pyqt >=5.15.7,<6.0.0
+    - qt >=5.9.7,<6.0.0
+    - pyqt
     - opencascade ==7.4.0
     - pythonocc-core ==7.4.1
     - tbb ==2019.5

--- a/cpacscreator/meta.yaml
+++ b/cpacscreator/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - tbb-devel ==2019.5
     - python {{ python }}
     - libglu                            # [linux]
-    - qt >=5.9.7,<6.0.0
+    - qt ==5.15.7
 
   run:
     - tixi3 ==3.3.0


### PR DESCRIPTION
This PR also pins the host-requirement on qt to 5.15.7, because for some to me inexplicable reason, conda-build picks up 5.15.9 when building cpacscreator on linux and then restricts the run-dependency to >=5.15.9<5.16. But this is 

1) too restrictive
2) not available on conda-forge

When forcing conda-build to use 5.15.7, the resulting run-requirement on linux is less strict.