### PR TITLE
Add conda recipe for opencascade static

### DIFF
--- a/freeimageplus-static/bld.bat
+++ b/freeimageplus-static/bld.bat
@@ -1,0 +1,29 @@
+mkdir buildd
+cd buildd
+
+REM Configure step
+cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+ -DCMAKE_BUILD_TYPE=Release ^
+ -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+ -DOCE_WIN_BUNDLE_INSTALL_DIR="%LIBRARY_PREFIX%" ^
+ -DBUNDLE_BUILD_FREEIMAGE=ON ^
+ -DBUNDLE_BUILD_FREETYPE=OFF ^
+ -DBUNDLE_BUILD_GL2PS=OFF ^
+ -DBUNDLE_SHARED_LIBRARIES=OFF ^
+ -DOCE_MULTITHREAD_LIBRARY=OpenMP ^
+ ..
+if errorlevel 1 exit 1
+
+REM Build step 
+ninja
+if errorlevel 1 exit 1
+
+REM Install step
+ninja install
+if errorlevel 1 exit 1
+
+REM fix non-standard include location
+copy "%LIBRARY_PREFIX%"\include\FreeImage\FreeImage.h "%LIBRARY_PREFIX%"\include
+copy "%LIBRARY_PREFIX%"\include\FreeImage\FreeImagePlus.h "%LIBRARY_PREFIX%"\include
+rmdir /S /Q "%LIBRARY_PREFIX%"\include\FreeImage
+

--- a/freeimageplus-static/build.sh
+++ b/freeimageplus-static/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Build step 
+make -j $CPU_COUNT -f Makefile.fip libfreeimageplus.a
+
+mkdir $PREFIX/include
+cp Source/FreeImage.h $PREFIX/include
+cp Wrapper/FreeImagePlus/FreeImagePlus.h $PREFIX/include
+mkdir $PREFIX/lib
+cp *.a $PREFIX/lib
+cd $PREFIX/lib
+ln -s libfreeimageplus.a libfreeimage.a
+

--- a/freeimageplus-static/installdir.patch
+++ b/freeimageplus-static/installdir.patch
@@ -1,0 +1,13 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 8f8a648..c374ae6 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -72,7 +72,7 @@ IF(MINGW)
+ ENDIF()
+ 
+ 
+-SET( OCE_WIN_BUNDLE_INSTALL_DIR_BITS ${OCE_WIN_BUNDLE_INSTALL_DIR}/Win${BIT}/)
++SET( OCE_WIN_BUNDLE_INSTALL_DIR_BITS ${OCE_WIN_BUNDLE_INSTALL_DIR}/)
+ SET( OCE_BUNDLE_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR} )
+ 
+ # Adds freetype and related variables

--- a/freeimageplus-static/installlinux.patch
+++ b/freeimageplus-static/installlinux.patch
@@ -1,0 +1,32 @@
+diff --git Dist/delete.me Dist/delete.me
+deleted file mode 100644
+index e69de29..0000000
+diff --git Makefile.gnu Makefile.gnu
+index 92f6358..85ed430 100644
+--- Makefile.gnu
++++ Makefile.gnu
+@@ -4,9 +4,8 @@
+ include Makefile.srcs
+ 
+ # General configuration variables:
+-DESTDIR ?= /
+-INCDIR ?= $(DESTDIR)/usr/include
+-INSTALLDIR ?= $(DESTDIR)/usr/lib
++INCDIR ?= $(PREFIX)/include
++INSTALLDIR ?= $(PREFIX)/lib
+ 
+ # Converts cr/lf to just lf
+ DOS2UNIX = dos2unix
+@@ -71,9 +70,9 @@ $(SHAREDLIB): $(MODULES)
+ 
+ install:
+ 	install -d $(INCDIR) $(INSTALLDIR)
+-	install -m 644 -o root -g root $(HEADER) $(INCDIR)
+-	install -m 644 -o root -g root $(STATICLIB) $(INSTALLDIR)
+-	install -m 755 -o root -g root $(SHAREDLIB) $(INSTALLDIR)
++	install -m 644  $(HEADER) $(INCDIR)
++	install -m 644  $(STATICLIB) $(INSTALLDIR)
++	install -m 755  $(SHAREDLIB) $(INSTALLDIR)
+ 	ln -sf $(SHAREDLIB) $(INSTALLDIR)/$(VERLIBNAME)
+ 	ln -sf $(VERLIBNAME) $(INSTALLDIR)/$(LIBNAME)	
+ #	ldconfig

--- a/freeimageplus-static/meta.yaml
+++ b/freeimageplus-static/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: freeimageplus-static
+  version: 3.18.0
+
+source:
+  fn: new-bundle.zip [win]
+  url: https://github.com/QbProg/oce-win-bundle/archive/qb/new-bundle.zip [win]
+  fn: FreeImage3180.zip [unix]
+  url: http://downloads.sourceforge.net/freeimage/FreeImage3180.zip [unix]
+  patches:
+    - installdir.patch   [win]
+    - installlinux.patch [linux]
+
+build:
+  number: 2
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+
+
+about:
+  home: http://freeimage.sourceforge.net/
+  license: GNU LPGL Version 2 and FreeImage Public License
+  summary: FreeImage, The productivity booster

--- a/freetype-static/bld.bat
+++ b/freetype-static/bld.bat
@@ -1,0 +1,19 @@
+mkdir buildd
+cd buildd
+
+REM Configure step
+cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+ -DCMAKE_BUILD_TYPE=Release ^
+ -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+ -DCMAKE_SYSTEM_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+ ..
+if errorlevel 1 exit 1
+
+REM Build step 
+ninja
+if errorlevel 1 exit 1
+
+REM Install step
+ninja install
+if errorlevel 1 exit 1
+

--- a/freetype-static/build.sh
+++ b/freetype-static/build.sh
@@ -1,0 +1,16 @@
+mkdir buildd
+cd buildd
+
+# Configure step
+cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX=$PREFIX \
+ -DCMAKE_BUILD_TYPE=Release \
+ -DCMAKE_PREFIX_PATH=$PREFIX \
+ -DCMAKE_SYSTEM_PREFIX_PATH=$PREFIX \
+ ..
+
+# Build step 
+ninja
+
+# Install step
+ninja install
+

--- a/freetype-static/meta.yaml
+++ b/freetype-static/meta.yaml
@@ -1,0 +1,26 @@
+{% set version = "2.6" %}
+
+package:
+  name: freetype-static
+  version: {{ version }}
+
+source:
+  fn: freetype-{{ version }}.tar.gz
+  url: http://download.savannah.gnu.org/releases/freetype/freetype-{{ version }}.tar.gz
+  md5: 1d733ea6c1b7b3df38169fbdbec47d2b
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - cmake
+    - ninja
+    - python
+
+
+about:
+  home: http://www.freetype.org/
+  license: GNU GPL Version 2 and FreeType License
+  summary: FreeType is a freely available software library to render fonts

--- a/opencascade-static/CMakeLists.txt
+++ b/opencascade-static/CMakeLists.txt
@@ -1,0 +1,10 @@
+# a little test to see if occt is installed
+project(occt_test_cmake NONE)
+cmake_minimum_required(VERSION 3.5)
+
+find_package(OpenCASCADE)
+if (OpenCASCADE_MAJOR_VERSION)
+  message(STATUS " Found OpenCASCADE version: ${OpenCASCADE_MAJOR_VERSION}.${OpenCASCADE_MINOR_VERSION}.${OpenCASCADE_MAINTENANCE_VERSION}")
+else(OpenCASCADE_MAJOR_VERSION)
+  message(FATAL_ERROR "could not find OpenCASCADE")
+endif(OpenCASCADE_MAJOR_VERSION)

--- a/opencascade-static/bld.bat
+++ b/opencascade-static/bld.bat
@@ -1,0 +1,25 @@
+mkdir build
+cd build
+
+REM Configure step
+cmake -G "Ninja" .. ^
+      -D CMAKE_PREFIX_PATH:FILEPATH="%LIBRARY_PREFIX%" ^
+      -D CMAKE_INSTALL_PREFIX:FILEPATH="%LIBRARY_PREFIX%" ^
+      -D INSTALL_DIR_LAYOUT="Unix" ^
+      -D BUILD_MODULE_Draw=OFF ^
+      -D 3RDPARTY_DIR:FILEPATH="%LIBRARY_PREFIX%" ^
+      -D CMAKE_BUILD_TYPE="Release" ^
+      -D USE_TBB=ON ^
+      -D USE_FREEIMAGE=ON ^
+      -D BUILD_LIBRARY_TYPE=Static ^
+      -D BUILD_RELEASE_DISABLE_EXCEPTIONS=OFF
+
+if errorlevel 1 exit 1
+
+REM Build step 
+cmake --build .
+if errorlevel 1 exit 1
+
+REM Install step
+cmake --build . --target install
+if errorlevel 1 exit 1

--- a/opencascade-static/build.sh
+++ b/opencascade-static/build.sh
@@ -1,0 +1,29 @@
+
+declare -a CMAKE_PLATFORM_FLAGS
+if [[ ${HOST} =~ .*linux.* ]]; then
+    CMAKE_PLATFORM_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE="${RECIPE_DIR}/cross-linux.cmake")
+fi
+
+
+mkdir -p build
+cd build
+
+echo "HERE: $SRC_DIR" ${CMAKE_PLATFORM_FLAGS[@]}
+
+cmake -G "Ninja" .. \
+      -DCMAKE_BUILD_TYPE=Release \
+       ${CMAKE_PLATFORM_FLAGS[@]} \
+      -D CMAKE_INSTALL_PREFIX:FILEPATH=$PREFIX \
+      -D CMAKE_PREFIX_PATH:FILEPATH=$PREFIX \
+      -D 3RDPARTY_DIR:FILEPATH=$PREFIX \
+      -D BUILD_MODULE_Draw:BOOL=OFF \
+      -D USE_TBB:BOOL=ON \
+      -D USE_FREEIMAGE:BOOL=ON \
+      -D BUILD_LIBRARY_TYPE=Static \
+      -D BUILD_RELEASE_DISABLE_EXCEPTIONS=OFF \
+
+# Build step
+cmake --build . 
+
+# Install step
+cmake --build .  --target install

--- a/opencascade-static/cross-linux.cmake
+++ b/opencascade-static/cross-linux.cmake
@@ -1,0 +1,16 @@
+# this one is important
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_PLATFORM Linux)
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER $ENV{CC})
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH $ENV{PREFIX} $ENV{BUILD_PREFIX}/$ENV{HOST}/sysroot)
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/opencascade-static/dlr-feature-coons_c2.patch
+++ b/opencascade-static/dlr-feature-coons_c2.patch
@@ -1,0 +1,322 @@
+From f7278d6608f47e0bf0c91c6ea83df016889057ca Mon Sep 17 00:00:00 2001
+From: Martin Siggel <martin.siggel@dlr.de>
+Date: Tue, 25 May 2021 19:13:47 +0200
+Subject: [PATCH] Coons C2 Patch developed for DLR
+
+---
+ src/GeomFill/GeomFill_BSplineCurves.cxx | 92 ++++++++++++++++++++++---
+ src/GeomFill/GeomFill_BSplineCurves.hxx |  2 +-
+ src/GeomFill/GeomFill_Coons.cxx         | 55 ++++++++++-----
+ src/GeomFill/GeomFill_Coons.hxx         |  8 +--
+ src/GeomFill/GeomFill_FillingStyle.hxx  |  3 +-
+ 5 files changed, 129 insertions(+), 31 deletions(-)
+
+diff --git a/src/GeomFill/GeomFill_BSplineCurves.cxx b/src/GeomFill/GeomFill_BSplineCurves.cxx
+index 57c9a01f..a038e40a 100644
+--- a/src/GeomFill/GeomFill_BSplineCurves.cxx
++++ b/src/GeomFill/GeomFill_BSplineCurves.cxx
+@@ -211,7 +211,7 @@ GeomFill_BSplineCurves::GeomFill_BSplineCurves
+    const Handle(Geom_BSplineCurve)& C4, 
+    const GeomFill_FillingStyle Type      )
+ {
+-  Init( C1, C2, C3, C4, Type);
++  Init( C1, C2, C3, C4, Type, Precision::Confusion() );
+ }
+ 
+ 
+@@ -254,12 +254,13 @@ void  GeomFill_BSplineCurves::Init
+    const Handle(Geom_BSplineCurve)& C2, 
+    const Handle(Geom_BSplineCurve)& C3, 
+    const Handle(Geom_BSplineCurve)& C4, 
+-   const GeomFill_FillingStyle Type      )
++   const GeomFill_FillingStyle Type,
++   const Standard_Real Tol,
++   const Standard_Boolean SetSameDistr)
+ {
+   // On ordonne les courbes
+   Handle(Geom_BSplineCurve) CC1, CC2, CC3, CC4;
+   
+-  Standard_Real Tol = Precision::Confusion();
+ #ifndef No_Exception
+   Standard_Boolean IsOK =
+ #endif
+@@ -281,12 +282,79 @@ void  GeomFill_BSplineCurves::Init
+   if ( Deg4 < DegV) CC4->IncreaseDegree(DegV);
+ 
+   // Mise en conformite des distributions de noeuds
+-  Standard_Integer NbUPoles = SetSameDistribution(CC1,CC3);
+-  Standard_Integer NbVPoles = SetSameDistribution(CC2,CC4);
++  Standard_Integer NbUPoles, NbVPoles;
++  if(SetSameDistr)
++  {
++    NbUPoles = SetSameDistribution(CC1,CC3);
++    NbVPoles = SetSameDistribution(CC2,CC4);
++  }
++  else
++  {
++    NbUPoles = CC1->NbPoles();
++    NbVPoles = CC2->NbPoles();
++  }
+ 
+-  if(Type == GeomFill_CoonsStyle) {
+-    if(NbUPoles < 4 || NbVPoles < 4)
+-      throw Standard_ConstructionError("GeomFill_BSplineCurves: invalid filling style");
++  if(Type == GeomFill_CoonsStyle || Type == GeomFill_CoonsC2Style) {
++    //Standard_ConstructionError_Raise_if 
++    //  (NbUPoles < 4 || NbVPoles < 4, " GeomFill_BSplineCurves: invalid filling style");
++    Standard_Integer NbPolesMin = 4;
++    Standard_Integer aCont = 1;
++    if(Type == GeomFill_CoonsC2Style) {
++      NbPolesMin = 6;
++      aCont = 2;
++    }
++    while(NbUPoles < NbPolesMin)
++    {
++      if(CC1->Degree() < CC1->MaxDegree ())
++      {
++        CC1->IncreaseDegree(CC1->Degree() + 1);
++        CC3->IncreaseDegree(CC3->Degree() + 1);
++      }
++      else
++      {
++        Standard_Integer j;
++        Standard_Integer anIndx = 0;
++        Standard_Real aKnt = -RealLast();
++        for(j = CC1->FirstUKnotIndex(); j < CC1->LastUKnotIndex(); ++j)
++        {
++          Standard_Real dt = CC1->Knot(j+1) - CC1->Knot(j);
++          if(dt > aKnt)
++          {
++            aKnt = dt;
++            anIndx = j;
++          }
++        }
++        aKnt = 0.5 * (CC1->Knot(anIndx+1) + CC1->Knot(anIndx));
++        CC1->InsertKnot (aKnt, CC1->Degree() - aCont);
++        CC3->InsertKnot (aKnt, CC3->Degree() - aCont);
++      }
++    }
++    while(NbVPoles < NbPolesMin)
++    {
++      if(CC2->Degree() < CC2->MaxDegree ())
++      {
++        CC2->IncreaseDegree(CC2->Degree() + 1);
++        CC4->IncreaseDegree(CC4->Degree() + 1);
++      }
++      else
++      {
++        Standard_Integer j;
++        Standard_Integer anIndx = 0;
++        Standard_Real aKnt = -RealLast();
++        for(j = CC2->FirstUKnotIndex(); j < CC2->LastUKnotIndex(); ++j)
++        {
++          Standard_Real dt = CC2->Knot(j+1) - CC2->Knot(j);
++          if(dt > aKnt)
++          {
++            aKnt = dt;
++            anIndx = j;
++          }
++        }
++        aKnt = 0.5 * (CC2->Knot(anIndx+1) + CC2->Knot(anIndx));
++        CC2->InsertKnot (aKnt, CC2->Degree() - aCont);
++        CC4->InsertKnot (aKnt, CC4->Degree() - aCont);
++      }
++    }
+   }
+ 
+   TColgp_Array1OfPnt P1(1,NbUPoles);
+@@ -335,6 +403,9 @@ void  GeomFill_BSplineCurves::Init
+       case GeomFill_CoonsStyle   :
+ 	Caro = GeomFill_Coons  ( P1, P4, P3, P2, W1, W4, W3, W2); 
+ 	break;
++      case GeomFill_CoonsC2Style :
++	Caro = GeomFill_Coons  ( P1, P4, P3, P2, W1, W4, W3, W2, Standard_True); 
++	break;
+       case GeomFill_CurvedStyle  :
+ 	Caro = GeomFill_Curved ( P1, P2, P3, P4, W1, W2, W3, W4); 
+ 	break;
+@@ -349,6 +420,9 @@ void  GeomFill_BSplineCurves::Init
+       case GeomFill_CoonsStyle   :
+ 	Caro = GeomFill_Coons  ( P1, P4, P3, P2); 
+ 	break;
++     case GeomFill_CoonsC2Style :
++	Caro = GeomFill_Coons  ( P1, P4, P3, P2, Standard_True); 
++	break;
+       case GeomFill_CurvedStyle  :
+ 	Caro = GeomFill_Curved ( P1, P2, P3, P4); 
+ 	break;
+@@ -426,7 +500,7 @@ void  GeomFill_BSplineCurves::Init
+   Knots( 2) = C2->Knot(C2->LastUKnotIndex());
+   Mults( 1) = Mults( 2) = 2;
+   C4 = new Geom_BSplineCurve( Poles, Knots, Mults, 1);
+-  Init( C1, C2, C3, C4, Type);
++  Init( C1, C2, C3, C4, Type, Precision::Confusion() );
+ }
+ 
+ 
+diff --git a/src/GeomFill/GeomFill_BSplineCurves.hxx b/src/GeomFill/GeomFill_BSplineCurves.hxx
+index e839213e..ff7927f8 100644
+--- a/src/GeomFill/GeomFill_BSplineCurves.hxx
++++ b/src/GeomFill/GeomFill_BSplineCurves.hxx
+@@ -69,7 +69,7 @@ public:
+   Standard_EXPORT GeomFill_BSplineCurves(const Handle(Geom_BSplineCurve)& C1, const Handle(Geom_BSplineCurve)& C2, const GeomFill_FillingStyle Type);
+   
+   //! if the curves cannot be joined
+-  Standard_EXPORT void Init (const Handle(Geom_BSplineCurve)& C1, const Handle(Geom_BSplineCurve)& C2, const Handle(Geom_BSplineCurve)& C3, const Handle(Geom_BSplineCurve)& C4, const GeomFill_FillingStyle Type);
++  Standard_EXPORT void Init (const Handle(Geom_BSplineCurve)& C1, const Handle(Geom_BSplineCurve)& C2, const Handle(Geom_BSplineCurve)& C3, const Handle(Geom_BSplineCurve)& C4, const GeomFill_FillingStyle Type, const Standard_Real Tolerance,const Standard_Boolean SetSameDistr = Standard_True);
+   
+   //! if the curves cannot be joined
+   Standard_EXPORT void Init (const Handle(Geom_BSplineCurve)& C1, const Handle(Geom_BSplineCurve)& C2, const Handle(Geom_BSplineCurve)& C3, const GeomFill_FillingStyle Type);
+diff --git a/src/GeomFill/GeomFill_Coons.cxx b/src/GeomFill/GeomFill_Coons.cxx
+index 58186db1..412fe118 100644
+--- a/src/GeomFill/GeomFill_Coons.cxx
++++ b/src/GeomFill/GeomFill_Coons.cxx
+@@ -38,9 +38,10 @@ GeomFill_Coons::GeomFill_Coons()
+ GeomFill_Coons::GeomFill_Coons(const TColgp_Array1OfPnt& P1, 
+ 			 const TColgp_Array1OfPnt& P2, 
+ 			 const TColgp_Array1OfPnt& P3, 
+-			 const TColgp_Array1OfPnt& P4)
++			 const TColgp_Array1OfPnt& P4, 
++			 const Standard_Boolean isC2)
+ {
+-  Init( P1, P2, P3, P4);
++  Init( P1, P2, P3, P4, isC2);
+ }
+ 
+ 
+@@ -56,9 +57,10 @@ GeomFill_Coons::GeomFill_Coons(const TColgp_Array1OfPnt&   P1,
+ 			 const TColStd_Array1OfReal& W1, 
+ 			 const TColStd_Array1OfReal& W2, 
+ 			 const TColStd_Array1OfReal& W3, 
+-			 const TColStd_Array1OfReal& W4)
++			 const TColStd_Array1OfReal& W4, 
++			 const Standard_Boolean isC2)
+ {
+-  Init( P1, P2, P3, P4, W1, W2, W3, W4);
++  Init( P1, P2, P3, P4, W1, W2, W3, W4, isC2);
+ }
+ 
+ 
+@@ -70,7 +72,8 @@ GeomFill_Coons::GeomFill_Coons(const TColgp_Array1OfPnt&   P1,
+ void  GeomFill_Coons::Init(const TColgp_Array1OfPnt& P1, 
+ 			const TColgp_Array1OfPnt& P2, 
+ 			const TColgp_Array1OfPnt& P3, 
+-			const TColgp_Array1OfPnt& P4)
++			const TColgp_Array1OfPnt& P4, 
++			const Standard_Boolean isC2)
+ {
+   Standard_DomainError_Raise_if
+     ( P1.Length() != P3.Length() || P2.Length() != P4.Length()," ");
+@@ -94,25 +97,45 @@ void  GeomFill_Coons::Init(const TColgp_Array1OfPnt& P1,
+     myPoles->SetValue( NPolU, i, P4(i));
+   }
+ 
++  Standard_Integer aNbCoeff = 4;
++  if(isC2)
++  {
++    aNbCoeff = 6;
++  }
++
+   // Calcul des coefficients multiplicateurs
+-  TColgp_Array1OfPnt Coef ( 1, 4);
+-  TColgp_Array1OfPnt Pole ( 1, 4);
++  TColgp_Array1OfPnt Coef ( 1, aNbCoeff);
++  TColgp_Array1OfPnt Pole ( 1, aNbCoeff);
+   TColgp_Array1OfPnt CoefU( 1, NPolU);
+   TColgp_Array1OfPnt CoefV( 1, NPolV);
+-  Coef( 4) = gp_Pnt(  2., -2., 0.);
+-  Coef( 3) = gp_Pnt( -3.,  3., 0.);
+-  Coef( 2) = gp_Pnt(  0.,  0., 0.);
+-  Coef( 1) = gp_Pnt(  1.,  0., 0.);
++  if(isC2)
++  {
++    //Coefficients of Hermite polynomial of 5 degree
++    Coef( 6) = gp_Pnt(  -6.,   6., 0.);
++    Coef( 5) = gp_Pnt(  15., -15., 0.);
++    Coef( 4) = gp_Pnt( -10.,  10., 0.);
++    Coef( 3) = gp_Pnt(   0.,   0., 0.);
++    Coef( 2) = gp_Pnt(   0.,   0., 0.);
++    Coef( 1) = gp_Pnt(   1.,   0., 0.); 
++  }
++  else
++  {
++    //Coefficients of Hermite polynomial of 3 degree
++    Coef( 4) = gp_Pnt(  2., -2., 0.);
++    Coef( 3) = gp_Pnt( -3.,  3., 0.);
++    Coef( 2) = gp_Pnt(  0.,  0., 0.);
++    Coef( 1) = gp_Pnt(  1.,  0., 0.);
++  }
+   PLib::CoefficientsPoles(Coef, PLib::NoWeights(),
+ 			  Pole, PLib::NoWeights());
+-  if (NPolU > 4) {
++  if (NPolU > aNbCoeff) {
+     BSplCLib::IncreaseDegree(NPolU-1, Pole, BSplCLib::NoWeights(), 
+ 			     CoefU, BSplCLib::NoWeights());
+   }
+   else {
+      CoefU = Pole;
+   }
+-  if (NPolV > 4) {
++  if (NPolV > aNbCoeff) {
+     BSplCLib::IncreaseDegree(NPolV-1, Pole, BSplCLib::NoWeights(), 
+ 			     CoefV, BSplCLib::NoWeights());
+   }
+@@ -164,8 +187,8 @@ void  GeomFill_Coons::Init(const TColgp_Array1OfPnt&   P1,
+ 			   const TColStd_Array1OfReal& W1, 
+ 			   const TColStd_Array1OfReal& W2, 
+ 			   const TColStd_Array1OfReal& W3,
+-			   const TColStd_Array1OfReal& W4
+-                          )
++			   const TColStd_Array1OfReal& W4,
++			   const Standard_Boolean isC2)
+ {
+ 
+   Standard_DomainError_Raise_if
+@@ -175,7 +198,7 @@ void  GeomFill_Coons::Init(const TColgp_Array1OfPnt&   P1,
+       W2.Length() != P2.Length() || 
+       W3.Length() != P3.Length() || 
+       W4.Length() != P4.Length()   , " ");
+-  Init(P1,P2,P3,P4);
++  Init(P1,P2,P3,P4, isC2);
+   IsRational = Standard_True;
+ 
+   Standard_Integer NPolU = W1.Length();
+diff --git a/src/GeomFill/GeomFill_Coons.hxx b/src/GeomFill/GeomFill_Coons.hxx
+index 46d7dc2f..57286522 100644
+--- a/src/GeomFill/GeomFill_Coons.hxx
++++ b/src/GeomFill/GeomFill_Coons.hxx
+@@ -36,13 +36,13 @@ public:
+   
+   Standard_EXPORT GeomFill_Coons();
+   
+-  Standard_EXPORT GeomFill_Coons(const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4);
++  Standard_EXPORT GeomFill_Coons(const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const Standard_Boolean isC2 = Standard_False);
+   
+-  Standard_EXPORT GeomFill_Coons(const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const TColStd_Array1OfReal& W1, const TColStd_Array1OfReal& W2, const TColStd_Array1OfReal& W3, const TColStd_Array1OfReal& W4);
++  Standard_EXPORT GeomFill_Coons(const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const TColStd_Array1OfReal& W1, const TColStd_Array1OfReal& W2, const TColStd_Array1OfReal& W3, const TColStd_Array1OfReal& W4,const Standard_Boolean isC2 = Standard_False);
+   
+-  Standard_EXPORT void Init (const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4);
++  Standard_EXPORT   void Init (const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const Standard_Boolean isC2 = Standard_False);
+   
+-  Standard_EXPORT void Init (const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const TColStd_Array1OfReal& W1, const TColStd_Array1OfReal& W2, const TColStd_Array1OfReal& W3, const TColStd_Array1OfReal& W4);
++  Standard_EXPORT   void Init (const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const TColStd_Array1OfReal& W1, const TColStd_Array1OfReal& W2, const TColStd_Array1OfReal& W3, const TColStd_Array1OfReal& W4, const Standard_Boolean isC2 = Standard_False);
+ 
+ 
+ 
+diff --git a/src/GeomFill/GeomFill_FillingStyle.hxx b/src/GeomFill/GeomFill_FillingStyle.hxx
+index 23a7a4c9..0d947f92 100644
+--- a/src/GeomFill/GeomFill_FillingStyle.hxx
++++ b/src/GeomFill/GeomFill_FillingStyle.hxx
+@@ -26,7 +26,8 @@ enum GeomFill_FillingStyle
+ {
+ GeomFill_StretchStyle,
+ GeomFill_CoonsStyle,
+-GeomFill_CurvedStyle
++GeomFill_CurvedStyle,
++GeomFill_CoonsC2Style
+ };
+ 
+ #endif // _GeomFill_FillingStyle_HeaderFile
+-- 
+2.31.1.windows.1
+

--- a/opencascade-static/fix-private-linking.patch
+++ b/opencascade-static/fix-private-linking.patch
@@ -1,0 +1,13 @@
+Index: opencascade-7.4.0/adm/cmake/occt_toolkit.cmake
+===================================================================
+--- opencascade-7.4.0.orig/adm/cmake/occt_toolkit.cmake
++++ opencascade-7.4.0/adm/cmake/occt_toolkit.cmake
+@@ -354,7 +354,7 @@ else()
+ endif()
+ 
+ if (BUILD_SHARED_LIBS)
+-  target_link_libraries (${PROJECT_NAME} ${USED_TOOLKITS_BY_CURRENT_PROJECT} ${USED_EXTERNAL_LIBS_BY_CURRENT_PROJECT})
++  target_link_libraries (${PROJECT_NAME} PUBLIC ${USED_TOOLKITS_BY_CURRENT_PROJECT} PRIVATE ${USED_EXTERNAL_LIBS_BY_CURRENT_PROJECT})
+ endif()
+ 
+ if (USE_QT)

--- a/opencascade-static/meta.yaml
+++ b/opencascade-static/meta.yaml
@@ -1,0 +1,70 @@
+{% set name = "opencascade-static" %}
+{% set version = "7.6.2" %}
+{% set commit = "V7_6_2" %}
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h={{ commit }};sf=tgz
+  sha256: 9f7285acdfe63754955dfba1114010d5f273ac2be189c9717c4228bb28fd675f
+  patches:
+    - fix-private-linking.patch
+    - dlr-feature-coons_c2.patch
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: True
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ cdt('mesa-libgl-devel') }}     # [linux]
+    - {{ cdt('libxcb') }}               # [linux]
+    - {{ cdt('libxi-devel') }}          # [linux]
+    - {{ cdt('libx11-devel') }}         # [linux]
+    - {{ cdt('libxau-devel') }}         # [linux]
+    - {{ cdt('libxext-devel') }}        # [linux]
+    - {{ cdt('xorg-x11-proto-devel') }} # [linux]
+    - cmake
+    - ninja
+  host:
+    - libglu # [linux]
+    - freetype-static ==2.6
+    - freeimageplus-static ==3.18.0
+    - tbb
+    - tbb-devel
+    - python
+    - rapidjson
+    - fontconfig # [unix]
+
+  run:
+    - freeimageplus-static ==3.18.0
+    - tbb
+    - freetype-static ==2.6
+    - six
+    - rapidjson
+
+test:
+  requires:
+    - ninja
+    - cmake
+  files:
+    - CMakeLists.txt
+  commands:
+    - cmake -G "Ninja" .
+
+about:
+  home: https://www.opencascade.com/
+  license_family: LGPL
+  license: LGPL-2.1
+  license_file: LICENSE_LGPL_21.txt
+  summary: this is the occ (opencascade) CAD-Kernel
+  description: |
+    Open Cascade Technology (OCCT), formerly called CAS.CADE
+    is an open source software development platform for 3D CAD,
+    CAM, CAE, etc. that is developed and supported by Open Cascade SAS.
+  doc_url: https://www.opencascade.com/content/documentation
+  dev_url: http://git.dev.opencascade.org/gitweb/?p=occt.git
+


### PR DESCRIPTION
This is needed to bump the opencascade version in TiGL from 7.4 to 7.6 *(and soonish to 7.8 or 7.9)* because we build TiGL in CI/CD using static OCCT.