### PR TITLE
Bump opencascade-static build number

### DIFF
--- a/.github/workflows/build-conda-packages.yml
+++ b/.github/workflows/build-conda-packages.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ['x64']
-        os: [windows-2019, ubuntu-22.04, macos-latest]
+        os: [windows-2022, ubuntu-22.04, macos-latest]
         python: ['3.9', '3.10', '3.11', '3.12']
         exclude:
           - arch: x86

--- a/.github/workflows/build-conda-packages.yml
+++ b/.github/workflows/build-conda-packages.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ['x64']
-        os: [windows-2022, ubuntu-22.04, macos-latest]
+        os: [windows-latest, ubuntu-22.04, macos-latest]
         python: ['3.9', '3.10', '3.11', '3.12']
         exclude:
           - arch: x86

--- a/.github/workflows/build-conda-packages.yml
+++ b/.github/workflows/build-conda-packages.yml
@@ -48,15 +48,6 @@ jobs:
         python-version: ${{ matrix.python }}
         channels: dlr-sc,dlr-sc/label/tigl-dev
 
-    - name: Install compiler (macos)
-      if: contains(matrix.os, 'macos')
-      shell: bash -l {0}
-      run: |
-        /usr/bin/curl -o MacOSX10.9.sdk.tar.xz -L https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz
-        tar xf MacOSX10.9.sdk.tar.xz
-        sudo mv MacOSX10.9.sdk /opt/
-        ls /opt
-
     - name: Install requirements (ubuntu, macos)
       if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}

--- a/.github/workflows/build-conda-packages.yml
+++ b/.github/workflows/build-conda-packages.yml
@@ -74,6 +74,10 @@ jobs:
         python --version
         python build_recipes.py
 
+    - name: setup MSVC
+      if: contains(matrix.os, 'windows')
+      uses: ilammy/msvc-dev-cmd@v1
+
     - name: build conda packages
       if: contains(matrix.os, 'windows')
       shell: cmd /C call {0}

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,5 +1,5 @@
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.9.sdk       # [osx]
+MACOSX_SDK_VERSION:
+  - '10.14'                   # [osx]
   
 c_compiler:
  - vs2015                     # [win]

--- a/opencascade-static/meta.yaml
+++ b/opencascade-static/meta.yaml
@@ -15,7 +15,7 @@ source:
     - dlr-feature-coons_c2.patch
 
 build:
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: True
 
 requirements:


### PR DESCRIPTION
Because I suspect I statically linked in a broken FreeImage library

For this to work, I needed to
 - update the windows-runner, because windows-2019 is deprecated
 - explicitly activate the VS environment using an action, as it wasn't automatically picked up by conda-build on the new windows-runner
 - update the MacOS SDK. Also, now I am using the SDK pre-installed on the Github-hosted runner